### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ roadtools==0.0.1
 roadtx==1.4.3
 selenium==4.14.0
 selenium_wire==5.1.0
+blinker==1.7.0


### PR DESCRIPTION
Fixing "No module named 'blinker._saferef'" by define blinker version in requirements.txt. See: https://github.com/seleniumbase/SeleniumBase/issues/2782